### PR TITLE
Commit of throw bug fix

### DIFF
--- a/GameDev2Project/Assets/Prefabs/Guns/Sniper Rifle.prefab
+++ b/GameDev2Project/Assets/Prefabs/Guns/Sniper Rifle.prefab
@@ -338,7 +338,7 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.1, y: 0.2, z: 1.2}
+  m_Size: {x: 0.05, y: 0.2, z: 1.2}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!54 &1943847716549970300
 Rigidbody:

--- a/GameDev2Project/Assets/Scenes/Deven Wyckoff.unity
+++ b/GameDev2Project/Assets/Scenes/Deven Wyckoff.unity
@@ -962,6 +962,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: Throwables
       objectReference: {fileID: 0}
+    - target: {fileID: 6315703019418088957, guid: 3fb68b906afefd54db173fe9c39df8de, type: 3}
+      propertyPath: throwDamage
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6315703019418088957, guid: 3fb68b906afefd54db173fe9c39df8de, type: 3}
+      propertyPath: throwableHP
+      value: 10000000
+      objectReference: {fileID: 0}
+    - target: {fileID: 6888242220063757378, guid: 3fb68b906afefd54db173fe9c39df8de, type: 3}
+      propertyPath: m_Mass
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6888242220063757378, guid: 3fb68b906afefd54db173fe9c39df8de, type: 3}
+      propertyPath: m_IsKinematic
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6888242220063757378, guid: 3fb68b906afefd54db173fe9c39df8de, type: 3}
+      propertyPath: m_ExcludeLayers.m_Bits
+      value: 8
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1290,6 +1310,22 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 4534222317438887794, guid: e62a00fbd7949c749bf5d69d5f17b7bd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4534222317438887794, guid: e62a00fbd7949c749bf5d69d5f17b7bd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4862857840593933731, guid: e62a00fbd7949c749bf5d69d5f17b7bd, type: 3}
+      propertyPath: isEquiped
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4862857840593933731, guid: e62a00fbd7949c749bf5d69d5f17b7bd, type: 3}
+      propertyPath: throwForce
+      value: 3500
+      objectReference: {fileID: 0}
     - target: {fileID: 4903557523860850379, guid: e62a00fbd7949c749bf5d69d5f17b7bd, type: 3}
       propertyPath: m_LocalPosition.x
       value: -0.9800005
@@ -1517,6 +1553,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 75879933605772206, guid: 07d3954c239ccfd468f7cdd0c31ec6f4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1943847716549970300, guid: 07d3954c239ccfd468f7cdd0c31ec6f4, type: 3}
+      propertyPath: m_ImplicitCom
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3961228103130424275, guid: 07d3954c239ccfd468f7cdd0c31ec6f4, type: 3}

--- a/GameDev2Project/Assets/Scripts/throwPhysics.cs
+++ b/GameDev2Project/Assets/Scripts/throwPhysics.cs
@@ -15,6 +15,7 @@ public class throwPhysics : MonoBehaviour
 
     public GameObject throwable;
     Rigidbody throwableRb;
+    bool throwableRbDefaultGravity;
     bool isHolding = false;
 
 
@@ -111,10 +112,12 @@ public class throwPhysics : MonoBehaviour
             {
                 throwable = hit.collider.gameObject;
                 throwableRb = throwable.GetComponent<Rigidbody>();
+                throwableRbDefaultGravity = throwableRb.useGravity;
 
                 if (throwableRb != null)
                 {
                     throwable.transform.SetParent(handPosition);
+                    throwableRb.useGravity = false;
                     isHolding = true;
                 }
             }
@@ -129,23 +132,19 @@ public class throwPhysics : MonoBehaviour
 
             throwable.transform.SetParent(null);
             throwable.transform.position = throwPosition.position;
-            throwable.transform.rotation = throwPosition.rotation;
             throwable = null;
+            throwableRb.useGravity = throwableRbDefaultGravity;
         }
     }
 
     void ThrowObject()
     {
-        if (throwable != null)
-        {
-            DropObject();
             if (throwableRb != null)
             {
-
-                throwableRb.AddForce(Camera.main.transform.forward * throwForce, ForceMode.Impulse);
-                throwableRb.AddForce(Camera.main.transform.up * throwForce / 5, ForceMode.Impulse);
+            DropObject();
+            throwableRb.AddForce(throwableRb.transform.forward * throwForce, ForceMode.Impulse);
             }
-        }
+            
     }
 
 


### PR DESCRIPTION
Objects where thrown at ground due to accumulating gravity while held. This disables gravity on the object while held if it had gravity when picked up, and reactivates it when thrown.